### PR TITLE
Fixed syntax error in RHEL7/8 Rsyslog config

### DIFF
--- a/SOURCES/haproxy.syslog.el7
+++ b/SOURCES/haproxy.syslog.el7
@@ -6,6 +6,8 @@ $template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-la
 $template HAProxyAccess,"%msg%\n"
 
 local2.=info if $programname startswith 'haproxy' then /var/log/haproxy/access.log;HAProxyAccess 
+& stop
 local2.emerg if $programname startswith 'haproxy' then /var/log/haproxy/error.log;HAProxy
+& stop
 local2.notice if $programname startswith 'haproxy' then /var/log/haproxy/status.log;HAProxy
-local2.* & stop
+& stop

--- a/SOURCES/haproxy.syslog.el8
+++ b/SOURCES/haproxy.syslog.el8
@@ -6,6 +6,8 @@ $template HAProxy,"%TIMESTAMP% %syslogseverity-text:::UPPERCASE%: %msg:::drop-la
 $template HAProxyAccess,"%msg%\n"
 
 local2.=info if $programname startswith 'haproxy' then /var/log/haproxy/access.log;HAProxyAccess 
+& stop
 local2.emerg if $programname startswith 'haproxy' then /var/log/haproxy/error.log;HAProxy
+& stop
 local2.notice if $programname startswith 'haproxy' then /var/log/haproxy/status.log;HAProxy
-local2.* & stop
+& stop


### PR DESCRIPTION
This patch fixes an invalid Rsyslog configuration for RHEL7/8.

Steps to reproduce:
1. Install HAProxy
2. Run `rsyslogd -N3` to find out there are syntax errors:
```
# rsyslogd -N3
rsyslogd: version 8.24.0-57.el7_9.1, config validation run (level 3), master config /etc/rsyslog.conf
rsyslogd: error during parsing file /etc/rsyslog.d/49-haproxy.conf, on or before line 11: syntax error on token '&' [v8.24.0-57.el7_9.1 try http://www.rsyslog.com/e/2207 ]
rsyslogd: CONFIG ERROR: could not interpret master config file '/etc/rsyslog.conf'. [v8.24.0-57.el7_9.1 try http://www.rsyslog.com/e/2207 ]
```
3. Notice that it looks like that Rsyslog is still running fine (it starts normally and `systemctl status rsyslog` show no errors), but Rsyslog completely stopped logging to /var/log/messages, /var/log/cron, /var/log/maillog, and other log files! Actually, no new messages will appear in these log files after you install HAProxy.
